### PR TITLE
Hide C++ sources by default when nuget pkg is added to a new project

### DIFF
--- a/source/Microsoft.IoT.SDKFromArduino.nuspec
+++ b/source/Microsoft.IoT.SDKFromArduino.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.IoT.SDKFromArduino</id>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <title>Arduino SDK</title>
     <authors>Microsoft Open Technologies, Inc.</authors>
     <owners>Microsoft Open Technologies, Inc. </owners>

--- a/source/Microsoft.IoT.SDKFromArduino.targets
+++ b/source/Microsoft.IoT.SDKFromArduino.targets
@@ -9,11 +9,16 @@
     </ResourceCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="$(MSBuildThisFileDirectory)\Source\IPAddress.cpp" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)\Source\LiquidCrystal.cpp" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)\Source\Print.cpp" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)\Source\Stepper.cpp" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)\Source\Stream.cpp" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)\Source\WString.cpp" />
+    <ArduinoSDKSources Include="$(MSBuildThisFileDirectory)\Source\IPAddress.cpp" />
+    <ArduinoSDKSources Include="$(MSBuildThisFileDirectory)\Source\LiquidCrystal.cpp" />
+    <ArduinoSDKSources Include="$(MSBuildThisFileDirectory)\Source\Print.cpp" />
+    <ArduinoSDKSources Include="$(MSBuildThisFileDirectory)\Source\Stepper.cpp" />
+    <ArduinoSDKSources Include="$(MSBuildThisFileDirectory)\Source\Stream.cpp" />
+    <ArduinoSDKSources Include="$(MSBuildThisFileDirectory)\Source\WString.cpp" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ClCompile Include="@(ArduinoSDKSources)" />
+  </ItemGroup>
+  
 </Project>


### PR DESCRIPTION
The change updates the targets file, so C++ sources are hidden by default
when the nuget package is added to a new VC++ project.
Additionally, the version number is bumped to 1.0.1